### PR TITLE
Make use of redis pub-sub for improved performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
     "uid2": "0.0.3",
     "redis": "0.10.1",
     "msgpack-js": "0.3.0",
-    "socket.io-adapter": "0.3.1"
+    "socket.io-adapter": "0.3.1",
+    "async": "0.2.10"
   },
   "devDependencies": {
     "socket.io": "1.0.2",
     "socket.io-client": "1.0.2",
     "mocha": "1.18.0",
-    "expect.js": "0.3.1",
-    "async": "0.2.10"
+    "expect.js": "0.3.1"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -169,7 +169,7 @@ describe('socket.io-redis', function(){
       }, function (err) {
         var pub = self.redisClients[0];
         pub.pubsub('numsub', 'socket.io#/nsp#room#', function (err, subscriptions) {
-          expect(subscriptions[1]).to.be('0');
+          expect(parseInt(subscriptions[1])).to.be(0);
           done(err);
         });
       });
@@ -187,7 +187,7 @@ describe('socket.io-redis', function(){
             var pub = self.redisClients[0];
 
             pub.pubsub('numsub', 'socket.io#/nsp#room#', function (err, subscriptions) {
-              expect(subscriptions[1]).to.be('0');
+              expect(parseInt(subscriptions[1])).to.be(0);
               done(err);
             });
           }, 20);

--- a/test/index.js
+++ b/test/index.js
@@ -40,12 +40,20 @@ describe('socket.io-redis', function(){
                 socket.join('room', callback);
               });
 
+              socket.on('leave', function(callback){
+                socket.leave('room', callback);
+              });
+
               socket.on('socket broadcast', function(data){
                 socket.broadcast.to('room').emit('broadcast', data);
               });
 
               socket.on('namespace broadcast', function(data){
                 sio.of('/nsp').in('room').emit('broadcast', data);
+              });
+
+              socket.on('request', function(data){
+                socket.emit('reply', data);
               });
             });
           });
@@ -123,6 +131,68 @@ describe('socket.io-redis', function(){
       }, done);
 
       this.sockets[0].emit('namespace broadcast', 'hi');
+    });
+
+    it('should reply to one client', function(done){
+      this.sockets.slice(1).forEach(function(socket){
+        socket.on('reply', function(message){
+          throw new Error('Called unexpectedly: other socket');
+        });
+      });
+
+      this.sockets[0].on('reply', function(message){
+        expect(message).to.equal('hi');
+        done();
+      });
+      this.sockets[0].emit('request', 'hi');
+    });
+
+    it('should not send message for clients left the room', function(done){
+      var self = this;
+
+      async.each(this.sockets, function(socket, next){
+        socket.on('broadcast', function(message){
+          throw new Error('Called unexpectedly: client already left the room');
+        });
+        socket.emit('leave', next);
+      }, function (err) {
+        self.sockets[0].emit('namespace broadcast', 'hi');
+        done();
+      });
+    });
+
+    it('should unsubscribe from the channel if there are no more room members', function(done){
+      var self = this;
+
+      async.each(this.sockets, function(socket, next){
+        socket.emit('leave', next);
+      }, function (err) {
+        var pub = self.redisClients[0];
+        pub.pubsub('numsub', 'socket.io#/nsp#room#', function (err, subscriptions) {
+          expect(subscriptions[1]).to.be('0');
+          done(err);
+        });
+      });
+    });
+
+    it('should unsubscribe from the channel if clients have disconnected', function(done){
+      var self = this;
+
+      setTimeout(function () {
+        async.each(self.sockets, function(socket, next){
+          socket.once('disconnect', next);
+          socket.disconnect();
+        }, function (err) {
+          setTimeout(function () {
+            var pub = self.redisClients[0];
+
+            pub.pubsub('numsub', 'socket.io#/nsp#room#', function (err, subscriptions) {
+              expect(subscriptions[1]).to.be('0');
+              done(err);
+            });
+          }, 20);
+        });
+      }, 20);
     });
   });
 });


### PR DESCRIPTION
Previously socket.io-redis was listening for the whole pattern socket.io#* and the messages were sent to socket.io#id. This means that all the socket.io servers will receive all messages, even if the server does not use that namespace, even if there are no client listening to any of those rooms on them. If there are some nodes which send a lot of message, all the socket.io servers will have 100% cpu really quickly.

I changed it to use socket.io#namespace#room in order to be able to filter the messages on the redis server already, so the socket.io servers will receive only the messages they need to receive.