### PR TITLE
For support latest msgpack v5, change msgpack-js to msgpack-js-v5

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
 
 var uid2 = require('uid2');
 var redis = require('redis').createClient;
-var msgpack = require('msgpack-js');
+var msgpack = require('msgpack-js-v5');
 var Adapter = require('socket.io-adapter');
 var Emitter = require('events').EventEmitter;
 var debug = require('debug')('socket.io-redis');

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "async": "0.9.0",
     "debug": "0.7.4",
-    "msgpack-js": "0.3.0",
+    "msgpack-js-v5": "^0.3.0-v5",
     "redis": "0.10.1",
     "socket.io-adapter": "automattic/socket.io-adapter#de5cba",
     "uid2": "0.0.3"


### PR DESCRIPTION
i had a problem when upgrade socket.io-ruby-emitter

i've got follow message

```
Error: -590689023 trailing bytes
```

msgpack-js does not support 'str8' type

https://github.com/msgpack/msgpack-ruby/issues/66

https://github.com/chakrit/msgpack-js



